### PR TITLE
Crypto API: AES, RSA, RNG and Base64

### DIFF
--- a/src/main/java/com/redtoast/APIS/Crypto/AES.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/AES.java
@@ -1,0 +1,116 @@
+package com.redtoast.APIS.Crypto;
+
+import com.redtoast.Computer;
+import com.redtoast.simulation.Runtime;
+import com.redtoast.simulation.annotations.Exposed;
+import com.redtoast.simulation.base.Exposable;
+
+import javax.crypto.*;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.*;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
+
+public class AES implements Exposable {
+    Computer computer;
+    Runtime vm;
+    static final String algorithm = "AES/GCM/NoPadding";
+
+    public AES(Computer parent) throws NoSuchAlgorithmException {
+        computer = parent;
+        vm = computer.getRuntime();
+    }
+    @Exposed
+    public static String generateIv() {
+        byte[] iv = new byte[12];
+        new SecureRandom().nextBytes(iv);
+        return Base64.getEncoder().encodeToString(iv);
+    }
+
+    @Exposed
+    public String GenerateKey() {
+        KeyGenerator keyGenerator = null;
+        try {
+            keyGenerator = KeyGenerator.getInstance("AES");
+        } catch (NoSuchAlgorithmException e) {
+            return null;
+        }
+        keyGenerator.init(256);
+        SecretKey key = keyGenerator.generateKey();
+        return Base64.getEncoder().encodeToString(key.getEncoded());
+    }
+    @Exposed
+    public String Encrypt(String SecretKey, String IV, String data) {
+        Cipher cipher;
+        SecretKey key;
+        SecretKeyFactory keyFactory;
+        try {
+            keyFactory = SecretKeyFactory.getInstance("AES");
+        } catch (NoSuchAlgorithmException e) {
+            return null;
+        }
+        try {
+            key = keyFactory.generateSecret(new SecretKeySpec(Base64.getDecoder().decode(SecretKey), "AES"));
+        } catch (InvalidKeySpecException e) {
+            return null;
+        }
+
+        try {
+            cipher = Cipher.getInstance(algorithm);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        } catch (NoSuchPaddingException e) {
+            return null;
+        }
+        try {
+            cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, Base64.getDecoder().decode(IV)));
+        } catch (InvalidKeyException | InvalidAlgorithmParameterException e) {
+            return null;
+        }
+        byte[] cipherText;
+        try {
+            cipherText = cipher.doFinal(data.getBytes(StandardCharsets.UTF_8));
+        } catch (IllegalBlockSizeException | BadPaddingException e) {
+            return null;
+        }
+        return Base64.getEncoder().encodeToString(cipherText);
+    }
+    @Exposed
+    public String Decrypt(String SecretKey, String IV, String data) {
+        Cipher cipher;
+        SecretKey key;
+        SecretKeyFactory keyFactory;
+        try {
+            keyFactory = SecretKeyFactory.getInstance("AES");
+        } catch (NoSuchAlgorithmException e) {
+            return null;
+        }
+        try {
+            key = keyFactory.generateSecret(new SecretKeySpec(Base64.getDecoder().decode(SecretKey), "AES"));
+        } catch (InvalidKeySpecException e) {
+            return null;
+        }
+
+        try {
+            cipher = Cipher.getInstance(algorithm);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        } catch (NoSuchPaddingException e) {
+            return null;
+        }
+        try {
+            cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, Base64.getDecoder().decode(IV)));
+        } catch (InvalidKeyException | InvalidAlgorithmParameterException e) {
+            return null;
+        }
+        byte[] cipherText;
+        try {
+            cipherText = cipher.doFinal(Base64.getDecoder().decode(data));
+        } catch (IllegalBlockSizeException | BadPaddingException e) {
+            return null;
+        }
+        return new String(cipherText, StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/com/redtoast/APIS/Crypto/CryptoAPI.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/CryptoAPI.java
@@ -5,7 +5,6 @@ import com.redtoast.simulation.APILoader;
 import com.redtoast.simulation.Runtime;
 import com.redtoast.simulation.base.API;
 import com.redtoast.simulation.value.ValueTypes.Table;
-import org.luaj.vm2.Lua;
 
 public class CryptoAPI implements API {
     Computer computer;
@@ -13,6 +12,7 @@ public class CryptoAPI implements API {
 
     RSA rsaInstance;
     AES aesInstance;
+    LuaCryptoHashing hashInstance;
     LuaCryptoSecureRNG rngInstance;
     LuaCryptoBase64 base64Instance;
 
@@ -36,6 +36,7 @@ public class CryptoAPI implements API {
         } catch (Exception e) {
             aesInstance = null;
         }
+        hashInstance = new LuaCryptoHashing();
         rngInstance = new LuaCryptoSecureRNG();
         base64Instance = new LuaCryptoBase64();
     }
@@ -44,7 +45,7 @@ public class CryptoAPI implements API {
     public Table postProcessing(Table self) {
         self.put("RSA", APILoader.TableizeAPI(rsaInstance, vm).asValue());
         self.put("AES", APILoader.TableizeAPI(aesInstance, vm).asValue());
-        //self.put("Hash", "TODO: Hashing instance");
+        self.put("Hash", APILoader.TableizeAPI(hashInstance, vm).asValue());
         self.put("SecureRNG", APILoader.TableizeAPI(rngInstance, vm).asValue());
         self.put("Base64", APILoader.TableizeAPI(base64Instance, vm).asValue());
         return self;

--- a/src/main/java/com/redtoast/APIS/Crypto/CryptoAPI.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/CryptoAPI.java
@@ -1,0 +1,43 @@
+package com.redtoast.APIS.Crypto;
+
+import com.redtoast.Computer;
+import com.redtoast.simulation.APILoader;
+import com.redtoast.simulation.Runtime;
+import com.redtoast.simulation.base.API;
+import com.redtoast.simulation.value.ValueTypes.Table;
+
+public class CryptoAPI implements API {
+    Computer computer;
+    Runtime vm;
+
+    RSA rsaInstance;
+
+    public CryptoAPI(Computer parent) {
+        computer = parent;
+        vm = computer.getRuntime();
+        /* fun HACK here!
+        * the java error handling makes it mandatory to handle all errors, including the most odd fuckery
+        * in this case, nonexistent algorithms. But RSA is also among the required ciphers for any java implementation,
+        * so what gives ?
+        * Just in case though, setting it to null will result in a null table entry, which to Lua code basically means
+        * nonexistent anyway.
+        */
+        try {
+            rsaInstance = new RSA(computer);
+        } catch (Exception e) {
+            rsaInstance = null;
+        }
+    }
+
+    @Override
+    public Table postProcessing(Table self) {
+        self.put("RSA", APILoader.TableizeAPI(rsaInstance, vm).asValue());
+        self.put("AES", "TODO: AES instance");
+        return self;
+    }
+
+    @Override
+    public String getLabel() {
+        return "crypto";
+    }
+}

--- a/src/main/java/com/redtoast/APIS/Crypto/CryptoAPI.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/CryptoAPI.java
@@ -13,7 +13,7 @@ public class CryptoAPI implements API {
 
     RSA rsaInstance;
     AES aesInstance;
-
+    LuaCryptoSecureRNG rngInstance;
     LuaCryptoBase64 base64Instance;
 
     public CryptoAPI(Computer parent) {
@@ -36,6 +36,7 @@ public class CryptoAPI implements API {
         } catch (Exception e) {
             aesInstance = null;
         }
+        rngInstance = new LuaCryptoSecureRNG();
         base64Instance = new LuaCryptoBase64();
     }
 
@@ -43,8 +44,8 @@ public class CryptoAPI implements API {
     public Table postProcessing(Table self) {
         self.put("RSA", APILoader.TableizeAPI(rsaInstance, vm).asValue());
         self.put("AES", APILoader.TableizeAPI(aesInstance, vm).asValue());
-        self.put("Hash", "TODO: Hashing instance");
-        self.put("SecureRNG", "TODO: Secure randomisation instance");
+        //self.put("Hash", "TODO: Hashing instance");
+        self.put("SecureRNG", APILoader.TableizeAPI(rngInstance, vm).asValue());
         self.put("Base64", APILoader.TableizeAPI(base64Instance, vm).asValue());
         return self;
     }

--- a/src/main/java/com/redtoast/APIS/Crypto/CryptoAPI.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/CryptoAPI.java
@@ -33,6 +33,8 @@ public class CryptoAPI implements API {
     public Table postProcessing(Table self) {
         self.put("RSA", APILoader.TableizeAPI(rsaInstance, vm).asValue());
         self.put("AES", "TODO: AES instance");
+        self.put("Hash", "TODO: Hashing instance");
+        self.put("SecureRNG", "TODO: Secure randomisation instance");
         return self;
     }
 

--- a/src/main/java/com/redtoast/APIS/Crypto/CryptoAPI.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/CryptoAPI.java
@@ -5,12 +5,16 @@ import com.redtoast.simulation.APILoader;
 import com.redtoast.simulation.Runtime;
 import com.redtoast.simulation.base.API;
 import com.redtoast.simulation.value.ValueTypes.Table;
+import org.luaj.vm2.Lua;
 
 public class CryptoAPI implements API {
     Computer computer;
     Runtime vm;
 
     RSA rsaInstance;
+    AES aesInstance;
+
+    LuaCryptoBase64 base64Instance;
 
     public CryptoAPI(Computer parent) {
         computer = parent;
@@ -27,14 +31,21 @@ public class CryptoAPI implements API {
         } catch (Exception e) {
             rsaInstance = null;
         }
+        try {
+            aesInstance = new AES(computer);
+        } catch (Exception e) {
+            aesInstance = null;
+        }
+        base64Instance = new LuaCryptoBase64();
     }
 
     @Override
     public Table postProcessing(Table self) {
         self.put("RSA", APILoader.TableizeAPI(rsaInstance, vm).asValue());
-        self.put("AES", "TODO: AES instance");
+        self.put("AES", APILoader.TableizeAPI(aesInstance, vm).asValue());
         self.put("Hash", "TODO: Hashing instance");
         self.put("SecureRNG", "TODO: Secure randomisation instance");
+        self.put("Base64", APILoader.TableizeAPI(base64Instance, vm).asValue());
         return self;
     }
 

--- a/src/main/java/com/redtoast/APIS/Crypto/LuaCryptoBase64.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/LuaCryptoBase64.java
@@ -1,0 +1,18 @@
+package com.redtoast.APIS.Crypto;
+
+import com.redtoast.simulation.annotations.Exposed;
+import com.redtoast.simulation.base.Exposable;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public class LuaCryptoBase64 implements Exposable {
+    @Exposed
+    public String Decode(String data) {
+        return Base64.getEncoder().encodeToString(data.getBytes(StandardCharsets.UTF_8));
+    }
+    @Exposed
+    public String Encode(String data) {
+        return new String(Base64.getDecoder().decode(data), StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/com/redtoast/APIS/Crypto/LuaCryptoHashing.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/LuaCryptoHashing.java
@@ -1,0 +1,30 @@
+package com.redtoast.APIS.Crypto;
+
+import com.redtoast.simulation.annotations.Exposed;
+import com.redtoast.simulation.base.Exposable;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+public class LuaCryptoHashing implements Exposable {
+    @Exposed
+    public String SHA256(String data) {
+        return digest(data, "SHA-256");
+    }
+    @Exposed
+    public String MD5(String data) {
+        return digest(data, "MD5");
+    }
+    String digest(String data, String digestAlgorithm) {
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance(digestAlgorithm);
+        } catch (NoSuchAlgorithmException e) {
+            return null;
+        }
+        byte[] encodedhash = digest.digest(data.getBytes(StandardCharsets.UTF_8));
+        return LuaCryptoUtils.bytesToHex(encodedhash);
+    }
+}

--- a/src/main/java/com/redtoast/APIS/Crypto/LuaCryptoSecureRNG.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/LuaCryptoSecureRNG.java
@@ -1,0 +1,28 @@
+package com.redtoast.APIS.Crypto;
+
+import com.redtoast.simulation.annotations.Exposed;
+import com.redtoast.simulation.base.Exposable;
+import com.redtoast.simulation.value.ValueTypes.Table;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+public class LuaCryptoSecureRNG implements Exposable {
+    @Exposed
+    public int GetRandomInt() {
+        return new SecureRandom().nextInt(Integer.MIN_VALUE, Integer.MAX_VALUE);
+    }
+    @Exposed
+    public int GetRandomIntFromMin(int min) {
+        return new SecureRandom().nextInt(min, Integer.MAX_VALUE);
+    }
+    @Exposed
+    public int GetRandomIntUpTo(int max) {
+        return new SecureRandom().nextInt(Integer.MIN_VALUE, max);
+    }
+    @Exposed
+    public int GetRandomBetween(int min, int max) {
+        return new SecureRandom().nextInt(min, max);
+    }
+}

--- a/src/main/java/com/redtoast/APIS/Crypto/LuaCryptoUtils.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/LuaCryptoUtils.java
@@ -1,0 +1,15 @@
+package com.redtoast.APIS.Crypto;
+
+public class LuaCryptoUtils {
+    public static String bytesToHex(byte[] hash) {
+        StringBuilder hexString = new StringBuilder(2 * hash.length);
+        for (byte b : hash) {
+            String hex = Integer.toHexString(b);
+            if (hex.length() == 1) {
+                hexString.append('0');
+            }
+            hexString.append(hex);
+        }
+        return hexString.toString();
+    }
+}

--- a/src/main/java/com/redtoast/APIS/Crypto/RSA.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/RSA.java
@@ -32,7 +32,7 @@ public class RSA implements Exposable {
 
     @Exposed
     public Tuple GenerateKeyPair() {
-        KeyPairGenerator generator = null;
+        KeyPairGenerator generator;
         try {
             generator = KeyPairGenerator.getInstance("RSA");
         } catch (NoSuchAlgorithmException e) {
@@ -85,7 +85,7 @@ public class RSA implements Exposable {
     }
     @Exposed
     public String Decrypt(String PrivateKey, String data) {
-        byte[] dataBytes = data.getBytes(StandardCharsets.UTF_8);
+        byte[] dataBytes = Base64.getDecoder().decode(data);
         byte[] privateKeyBytes = Base64.getDecoder().decode(PrivateKey);
         Cipher rsaCipher;
         try {
@@ -101,7 +101,7 @@ public class RSA implements Exposable {
         }
 
         try {
-            rsaCipher.init(Cipher.ENCRYPT_MODE, privateKeyInstance);
+            rsaCipher.init(Cipher.DECRYPT_MODE, privateKeyInstance);
         } catch (InvalidKeyException e) {
             return null;
         }
@@ -114,5 +114,69 @@ public class RSA implements Exposable {
         }
 
         return Base64.getEncoder().encodeToString(dataDecrypted);
+    }
+    @Exposed
+    public String Sign(String PrivateKey, String data) {
+        byte[] dataBytes = data.getBytes(StandardCharsets.UTF_8);
+        byte[] privateKeyBytes = Base64.getDecoder().decode(PrivateKey);
+        Signature rsaSigner;
+        try {
+            rsaSigner = Signature.getInstance("SHA256withRSA");
+        } catch (Exception e) {
+            return null;
+        }
+        PrivateKey privateKeyInstance;
+        try {
+            privateKeyInstance = keyFactoryRSA.generatePrivate(new PKCS8EncodedKeySpec(privateKeyBytes));
+        } catch (InvalidKeySpecException e) {
+            return null;
+        }
+        try {
+            rsaSigner.initSign(privateKeyInstance);
+        } catch (InvalidKeyException e) {
+            return null;
+        }
+        try {
+            rsaSigner.update(dataBytes);
+        } catch (SignatureException e) {
+            return null;
+        }
+        try {
+            return Base64.getEncoder().encodeToString(rsaSigner.sign());
+        } catch (SignatureException e) {
+            return null;
+        }
+    }
+    @Exposed
+    public boolean Verify(String PublicKey, String data, String signature) {
+        byte[] dataBytes = data.getBytes(StandardCharsets.UTF_8);
+        byte[] publicKeyBytes = Base64.getDecoder().decode(PublicKey);
+        Signature rsaSigner;
+        try {
+            rsaSigner = Signature.getInstance("SHA256withRSA");
+        } catch (Exception e) {
+            return false;
+        }
+        PublicKey publicKeyInstance;
+        try {
+            publicKeyInstance = keyFactoryRSA.generatePublic(new X509EncodedKeySpec(publicKeyBytes));
+        } catch (InvalidKeySpecException e) {
+            return false;
+        }
+        try {
+            rsaSigner.initVerify(publicKeyInstance);
+        } catch (InvalidKeyException e) {
+            return false;
+        }
+        try {
+            rsaSigner.update(dataBytes);
+        } catch (SignatureException e) {
+            return false;
+        }
+        try {
+            return rsaSigner.verify(Base64.getDecoder().decode(signature));
+        } catch (SignatureException e) {
+            return false;
+        }
     }
 }

--- a/src/main/java/com/redtoast/APIS/Crypto/RSA.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/RSA.java
@@ -1,0 +1,118 @@
+package com.redtoast.APIS.Crypto;
+
+import com.redtoast.Computer;
+import com.redtoast.simulation.Runtime;
+import com.redtoast.simulation.annotations.Exposed;
+import com.redtoast.simulation.base.Exposable;
+import com.redtoast.simulation.value.Value;
+import com.redtoast.simulation.value.ValueTypes.Tuple;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import java.nio.charset.StandardCharsets;
+import java.security.*;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+
+public class RSA implements Exposable {
+    Computer computer;
+    Runtime vm;
+
+    KeyFactory keyFactoryRSA;
+
+    public RSA(Computer parent) throws NoSuchAlgorithmException {
+        computer = parent;
+        vm = computer.getRuntime();
+
+        keyFactoryRSA = KeyFactory.getInstance("RSA");
+    }
+
+    @Exposed
+    public Tuple GenerateKeyPair() {
+        KeyPairGenerator generator = null;
+        try {
+            generator = KeyPairGenerator.getInstance("RSA");
+        } catch (NoSuchAlgorithmException e) {
+            return null;
+        }
+        generator.initialize(2048);
+        KeyPair keyPair = generator.generateKeyPair();
+        Key publicKey = keyPair.getPublic();
+        Key privateKey = keyPair.getPrivate();
+        byte[] KeyDataPublic = publicKey.getEncoded();
+        byte[] KeyDataPrivate = privateKey.getEncoded();
+
+
+        Tuple result = new Tuple();
+        result.add(Value.of(Base64.getEncoder().encodeToString(KeyDataPublic)));
+        result.add(Value.of(Base64.getEncoder().encodeToString(KeyDataPrivate)));
+        return result;
+    }
+    @Exposed
+    public String Encrypt(String PublicKey, String data) {
+        byte[] dataBytes = data.getBytes(StandardCharsets.UTF_8);
+        byte[] publicKeyBytes = Base64.getDecoder().decode(PublicKey);
+        Cipher rsaCipher;
+        try {
+            rsaCipher = Cipher.getInstance("RSA");
+        } catch (Exception e) {
+            return null;
+        }
+        Key publicKeyInstance;
+        try {
+            publicKeyInstance = keyFactoryRSA.generatePublic(new X509EncodedKeySpec(publicKeyBytes));
+        } catch (InvalidKeySpecException e) {
+            return null;
+        }
+
+        try {
+            rsaCipher.init(Cipher.ENCRYPT_MODE, publicKeyInstance);
+        } catch (InvalidKeyException e) {
+            return null;
+        }
+        byte[] dataEncrypted;
+
+        try {
+            dataEncrypted = rsaCipher.doFinal(dataBytes);
+        } catch (IllegalBlockSizeException | BadPaddingException e) {
+            return null;
+        }
+
+        return Base64.getEncoder().encodeToString(dataEncrypted);
+    }
+    @Exposed
+    public String Decrypt(String PrivateKey, String data) {
+        byte[] dataBytes = data.getBytes(StandardCharsets.UTF_8);
+        byte[] privateKeyBytes = Base64.getDecoder().decode(PrivateKey);
+        Cipher rsaCipher;
+        try {
+            rsaCipher = Cipher.getInstance("RSA");
+        } catch (Exception e) {
+            return null;
+        }
+        Key privateKeyInstance;
+        try {
+            privateKeyInstance = keyFactoryRSA.generatePrivate(new PKCS8EncodedKeySpec(privateKeyBytes));
+        } catch (InvalidKeySpecException e) {
+            return null;
+        }
+
+        try {
+            rsaCipher.init(Cipher.ENCRYPT_MODE, privateKeyInstance);
+        } catch (InvalidKeyException e) {
+            return null;
+        }
+        byte[] dataDecrypted;
+
+        try {
+            dataDecrypted = rsaCipher.doFinal(dataBytes);
+        } catch (IllegalBlockSizeException | BadPaddingException e) {
+            return null;
+        }
+
+        return Base64.getEncoder().encodeToString(dataDecrypted);
+    }
+}

--- a/src/main/java/com/redtoast/neet/NeetComputersServer.java
+++ b/src/main/java/com/redtoast/neet/NeetComputersServer.java
@@ -1,5 +1,6 @@
 package com.redtoast.neet;
 
+import com.redtoast.APIS.Crypto.CryptoAPI;
 import com.redtoast.Computer;
 import com.redtoast.Connections.PipeType;
 import com.redtoast.Lua.LuaMaster;
@@ -304,6 +305,10 @@ public class NeetComputersServer implements ModInitializer {
 		APILoader.register(new APIRegistry() {
 			@Override
 			public @NotNull API Create(Computer computer) {return new EventAPI(computer);}
+		});
+		APILoader.register(new APIRegistry() {
+			@Override
+			public @NotNull API Create(Computer computer) {return new CryptoAPI(computer);}
 		});
     }
 


### PR DESCRIPTION
Adds basic support for cryptographic functions. They pass Base 64 around for keys and encrypted value, for easier storage. Base 64 encode and decode is exposed through `crypto.Base64` Both currently set to use UTF-8.