### PR TITLE
Various fixes to the crypto API

### DIFF
--- a/src/main/java/com/redtoast/APIS/Crypto/AES.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/AES.java
@@ -1,29 +1,24 @@
 package com.redtoast.APIS.Crypto;
 
-import com.redtoast.Computer;
-import com.redtoast.simulation.Runtime;
 import com.redtoast.simulation.annotations.Exposed;
 import com.redtoast.simulation.base.Exposable;
+import com.redtoast.simulation.base.ExposedError;
 
 import javax.crypto.*;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.*;
-import java.security.spec.InvalidKeySpecException;
 import java.util.Base64;
 
 public class AES implements Exposable {
-    Computer computer;
-    Runtime vm;
     static final String algorithm = "AES/GCM/NoPadding";
 
-    public AES(Computer parent) throws NoSuchAlgorithmException {
-        computer = parent;
-        vm = computer.getRuntime();
+    public AES() {
+
     }
     @Exposed
-    public static String generateIv() {
+    public String GenerateIv() {
         byte[] iv = new byte[12];
         new SecureRandom().nextBytes(iv);
         return Base64.getEncoder().encodeToString(iv);
@@ -31,11 +26,11 @@ public class AES implements Exposable {
 
     @Exposed
     public String GenerateKey() {
-        KeyGenerator keyGenerator = null;
+        KeyGenerator keyGenerator;
         try {
             keyGenerator = KeyGenerator.getInstance("AES");
         } catch (NoSuchAlgorithmException e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
         keyGenerator.init(256);
         SecretKey key = keyGenerator.generateKey();
@@ -45,35 +40,26 @@ public class AES implements Exposable {
     public String Encrypt(String SecretKey, String IV, String data) {
         Cipher cipher;
         SecretKey key;
-        SecretKeyFactory keyFactory;
-        try {
-            keyFactory = SecretKeyFactory.getInstance("AES");
-        } catch (NoSuchAlgorithmException e) {
-            return null;
-        }
-        try {
-            key = keyFactory.generateSecret(new SecretKeySpec(Base64.getDecoder().decode(SecretKey), "AES"));
-        } catch (InvalidKeySpecException e) {
-            return null;
-        }
+
+        key = new SecretKeySpec(Base64.getDecoder().decode(SecretKey), "AES");
 
         try {
             cipher = Cipher.getInstance(algorithm);
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         } catch (NoSuchPaddingException e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
         try {
             cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, Base64.getDecoder().decode(IV)));
         } catch (InvalidKeyException | InvalidAlgorithmParameterException e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
         byte[] cipherText;
         try {
             cipherText = cipher.doFinal(data.getBytes(StandardCharsets.UTF_8));
         } catch (IllegalBlockSizeException | BadPaddingException e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
         return Base64.getEncoder().encodeToString(cipherText);
     }
@@ -81,35 +67,26 @@ public class AES implements Exposable {
     public String Decrypt(String SecretKey, String IV, String data) {
         Cipher cipher;
         SecretKey key;
-        SecretKeyFactory keyFactory;
-        try {
-            keyFactory = SecretKeyFactory.getInstance("AES");
-        } catch (NoSuchAlgorithmException e) {
-            return null;
-        }
-        try {
-            key = keyFactory.generateSecret(new SecretKeySpec(Base64.getDecoder().decode(SecretKey), "AES"));
-        } catch (InvalidKeySpecException e) {
-            return null;
-        }
+
+        key = new SecretKeySpec(Base64.getDecoder().decode(SecretKey), "AES");
 
         try {
             cipher = Cipher.getInstance(algorithm);
         } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         } catch (NoSuchPaddingException e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
         try {
             cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, Base64.getDecoder().decode(IV)));
         } catch (InvalidKeyException | InvalidAlgorithmParameterException e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
         byte[] cipherText;
         try {
             cipherText = cipher.doFinal(Base64.getDecoder().decode(data));
         } catch (IllegalBlockSizeException | BadPaddingException e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
         return new String(cipherText, StandardCharsets.UTF_8);
     }

--- a/src/main/java/com/redtoast/APIS/Crypto/CryptoAPI.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/CryptoAPI.java
@@ -27,15 +27,11 @@ public class CryptoAPI implements API {
         * nonexistent anyway.
         */
         try {
-            rsaInstance = new RSA(computer);
+            rsaInstance = new RSA();
         } catch (Exception e) {
             rsaInstance = null;
         }
-        try {
-            aesInstance = new AES(computer);
-        } catch (Exception e) {
-            aesInstance = null;
-        }
+        aesInstance = new AES();
         hashInstance = new LuaCryptoHashing();
         rngInstance = new LuaCryptoSecureRNG();
         base64Instance = new LuaCryptoBase64();

--- a/src/main/java/com/redtoast/APIS/Crypto/LuaCryptoHashing.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/LuaCryptoHashing.java
@@ -6,7 +6,6 @@ import com.redtoast.simulation.base.Exposable;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
 
 public class LuaCryptoHashing implements Exposable {
     @Exposed

--- a/src/main/java/com/redtoast/APIS/Crypto/LuaCryptoSecureRNG.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/LuaCryptoSecureRNG.java
@@ -7,19 +7,23 @@ import java.security.SecureRandom;
 
 public class LuaCryptoSecureRNG implements Exposable {
     @Exposed
-    public int GetRandomInt() {
-        return new SecureRandom().nextInt(Integer.MIN_VALUE, Integer.MAX_VALUE);
+    public double GetRandomInt() {
+        return new SecureRandom().nextDouble(Double.MIN_VALUE, Double.MAX_VALUE);
     }
     @Exposed
-    public int GetRandomIntFromMin(int min) {
-        return new SecureRandom().nextInt(min, Integer.MAX_VALUE);
+    public double GetRandomIntFromMin(double min) {
+        return new SecureRandom().nextDouble(min, Double.MAX_VALUE);
     }
     @Exposed
-    public int GetRandomIntUpTo(int max) {
-        return new SecureRandom().nextInt(Integer.MIN_VALUE, max);
+    public double GetRandomIntUpTo(double max) {
+        if (max == Double.MAX_VALUE)
+            return new SecureRandom().nextDouble(Double.MIN_VALUE, max);
+        return new SecureRandom().nextDouble(Double.MIN_VALUE, max + 1);
     }
     @Exposed
-    public int GetRandomBetween(int min, int max) {
-        return new SecureRandom().nextInt(min, max + 1);
+    public double GetRandomBetween(double min, double max) {
+        if (max == Double.MAX_VALUE)
+            return new SecureRandom().nextDouble(min, max);
+        return new SecureRandom().nextDouble(min, max + 1);
     }
 }

--- a/src/main/java/com/redtoast/APIS/Crypto/LuaCryptoSecureRNG.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/LuaCryptoSecureRNG.java
@@ -25,8 +25,8 @@ public class LuaCryptoSecureRNG implements Exposable {
     public double GetRandomBetween(double min, double max) {
         if (max == Double.MAX_VALUE)
             return new SecureRandom().nextDouble(min, max);
-        if (min > max)
-            throw new ExposedError("Minimum value greater than maximum");
+        if (min >= max)
+            throw new ExposedError("Minimum value greater or equal to maximum");
         return new SecureRandom().nextDouble(min, max + 1);
     }
 }

--- a/src/main/java/com/redtoast/APIS/Crypto/LuaCryptoSecureRNG.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/LuaCryptoSecureRNG.java
@@ -2,6 +2,7 @@ package com.redtoast.APIS.Crypto;
 
 import com.redtoast.simulation.annotations.Exposed;
 import com.redtoast.simulation.base.Exposable;
+import com.redtoast.simulation.base.ExposedError;
 
 import java.security.SecureRandom;
 
@@ -24,6 +25,8 @@ public class LuaCryptoSecureRNG implements Exposable {
     public double GetRandomBetween(double min, double max) {
         if (max == Double.MAX_VALUE)
             return new SecureRandom().nextDouble(min, max);
+        if (min > max)
+            throw new ExposedError("Minimum value greater than maximum");
         return new SecureRandom().nextDouble(min, max + 1);
     }
 }

--- a/src/main/java/com/redtoast/APIS/Crypto/LuaCryptoSecureRNG.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/LuaCryptoSecureRNG.java
@@ -2,11 +2,8 @@ package com.redtoast.APIS.Crypto;
 
 import com.redtoast.simulation.annotations.Exposed;
 import com.redtoast.simulation.base.Exposable;
-import com.redtoast.simulation.value.ValueTypes.Table;
 
-import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
-import java.util.Base64;
 
 public class LuaCryptoSecureRNG implements Exposable {
     @Exposed
@@ -23,6 +20,6 @@ public class LuaCryptoSecureRNG implements Exposable {
     }
     @Exposed
     public int GetRandomBetween(int min, int max) {
-        return new SecureRandom().nextInt(min, max);
+        return new SecureRandom().nextInt(min, max + 1);
     }
 }

--- a/src/main/java/com/redtoast/APIS/Crypto/RSA.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/RSA.java
@@ -148,28 +148,28 @@ public class RSA implements Exposable {
         try {
             rsaSigner = Signature.getInstance("SHA256withRSA");
         } catch (Exception e) {
-            return false;
+            throw new ExposedError(e.getMessage());
         }
         PublicKey publicKeyInstance;
         try {
             publicKeyInstance = keyFactoryRSA.generatePublic(new X509EncodedKeySpec(publicKeyBytes));
         } catch (InvalidKeySpecException e) {
-            return false;
+            throw new ExposedError(e.getMessage());
         }
         try {
             rsaSigner.initVerify(publicKeyInstance);
         } catch (InvalidKeyException e) {
-            return false;
+            throw new ExposedError(e.getMessage());
         }
         try {
             rsaSigner.update(dataBytes);
         } catch (SignatureException e) {
-            return false;
+            throw new ExposedError(e.getMessage());
         }
         try {
             return rsaSigner.verify(Base64.getDecoder().decode(signature));
         } catch (SignatureException e) {
-            return false;
+            throw new ExposedError(e.getMessage());
         }
     }
 }

--- a/src/main/java/com/redtoast/APIS/Crypto/RSA.java
+++ b/src/main/java/com/redtoast/APIS/Crypto/RSA.java
@@ -1,9 +1,8 @@
 package com.redtoast.APIS.Crypto;
 
-import com.redtoast.Computer;
-import com.redtoast.simulation.Runtime;
 import com.redtoast.simulation.annotations.Exposed;
 import com.redtoast.simulation.base.Exposable;
+import com.redtoast.simulation.base.ExposedError;
 import com.redtoast.simulation.value.Value;
 import com.redtoast.simulation.value.ValueTypes.Tuple;
 
@@ -18,15 +17,9 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 
 public class RSA implements Exposable {
-    Computer computer;
-    Runtime vm;
-
     KeyFactory keyFactoryRSA;
 
-    public RSA(Computer parent) throws NoSuchAlgorithmException {
-        computer = parent;
-        vm = computer.getRuntime();
-
+    public RSA() throws NoSuchAlgorithmException {
         keyFactoryRSA = KeyFactory.getInstance("RSA");
     }
 
@@ -36,7 +29,7 @@ public class RSA implements Exposable {
         try {
             generator = KeyPairGenerator.getInstance("RSA");
         } catch (NoSuchAlgorithmException e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
         generator.initialize(2048);
         KeyPair keyPair = generator.generateKeyPair();
@@ -59,26 +52,26 @@ public class RSA implements Exposable {
         try {
             rsaCipher = Cipher.getInstance("RSA");
         } catch (Exception e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
         Key publicKeyInstance;
         try {
             publicKeyInstance = keyFactoryRSA.generatePublic(new X509EncodedKeySpec(publicKeyBytes));
         } catch (InvalidKeySpecException e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
 
         try {
             rsaCipher.init(Cipher.ENCRYPT_MODE, publicKeyInstance);
         } catch (InvalidKeyException e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
         byte[] dataEncrypted;
 
         try {
             dataEncrypted = rsaCipher.doFinal(dataBytes);
         } catch (IllegalBlockSizeException | BadPaddingException e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
 
         return Base64.getEncoder().encodeToString(dataEncrypted);
@@ -91,26 +84,26 @@ public class RSA implements Exposable {
         try {
             rsaCipher = Cipher.getInstance("RSA");
         } catch (Exception e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
         Key privateKeyInstance;
         try {
             privateKeyInstance = keyFactoryRSA.generatePrivate(new PKCS8EncodedKeySpec(privateKeyBytes));
         } catch (InvalidKeySpecException e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
 
         try {
             rsaCipher.init(Cipher.DECRYPT_MODE, privateKeyInstance);
         } catch (InvalidKeyException e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
         byte[] dataDecrypted;
 
         try {
             dataDecrypted = rsaCipher.doFinal(dataBytes);
         } catch (IllegalBlockSizeException | BadPaddingException e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
 
         return Base64.getEncoder().encodeToString(dataDecrypted);
@@ -123,28 +116,28 @@ public class RSA implements Exposable {
         try {
             rsaSigner = Signature.getInstance("SHA256withRSA");
         } catch (Exception e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
         PrivateKey privateKeyInstance;
         try {
             privateKeyInstance = keyFactoryRSA.generatePrivate(new PKCS8EncodedKeySpec(privateKeyBytes));
         } catch (InvalidKeySpecException e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
         try {
             rsaSigner.initSign(privateKeyInstance);
         } catch (InvalidKeyException e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
         try {
             rsaSigner.update(dataBytes);
         } catch (SignatureException e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
         try {
             return Base64.getEncoder().encodeToString(rsaSigner.sign());
         } catch (SignatureException e) {
-            return null;
+            throw new ExposedError(e.getMessage());
         }
     }
     @Exposed


### PR DESCRIPTION
This pull request brings about many fixes to the Crypto API merged before.

AES and RSA have been given error message instead of fallback to null.

AES was improperly tested, resulting in a java API missunderstanding that made it impossible to recover generated secret keys. 

Secure RNG has been changed to cover the maximum being an exclusive bound to an inclusive one, for consistency with it's minimum.