### PR TITLE
Fixed the paths not resolving uppercase letters

### DIFF
--- a/src/main/java/com/redtoast/graphics/screens/BoilerplateScreen.java
+++ b/src/main/java/com/redtoast/graphics/screens/BoilerplateScreen.java
@@ -199,6 +199,7 @@ public abstract class BoilerplateScreen extends HandledScreen<RGBScreenHandler> 
             case GLFW_KEY_RIGHT_BRACKET -> shift ? '}' : ']';
             case GLFW_KEY_GRAVE_ACCENT -> shift ? '~' : '`';
             case GLFW_KEY_ENTER -> 13;
+            case GLFW_KEY_TAB -> 9;
             case GLFW_KEY_BACKSPACE, GLFW_KEY_DELETE -> 8;
             case GLFW_KEY_LEFT_SHIFT, GLFW_KEY_RIGHT_SHIFT -> 14;
             case GLFW_KEY_LEFT -> 128;

--- a/src/main/java/com/redtoast/simulation/FS/FileHelper.java
+++ b/src/main/java/com/redtoast/simulation/FS/FileHelper.java
@@ -71,7 +71,7 @@ public class FileHelper {
     public static boolean validatePathStatic(String path){
         path = path.replace('\\', '/');
         if (path.charAt(path.length()-1)!='/') path += '/';
-        return path.matches("^([a-zA-Z]+\\:\\/?)([a-z_\\-\\s0-9\\.]*[a-z_\\-\\s0-9]\\/)*$");
+        return path.matches("^([a-zA-Z]+\\:\\/?)([a-zA-Z_\\-\\s0-9\\.]*[a-zA-Z_\\-\\s0-9]\\/)*$");
     }
 
     public static boolean isSourceHardAddress(int source){


### PR DESCRIPTION
When trying to launch my OS, but it was rejecting paths that are including uppercase letters with "Not a file" error. Issue was in a regex inside FileHelper.java `"^([a-zA-Z]+\\:\\/?)([a-z_\\-\\s0-9\\.]*[a-z_\\-\\s0-9]\\/)*$"`, which rejected paths like this: `system:/Library/CoreServices/launchd/init.lua`, crashing the system with "Not a file" error.